### PR TITLE
change go get path

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Related projects:
 ## Install
 
 ```
-$ go get github.com/miku/zek/cmd/...
+$ go get github.com/miku/zek/cmd/zek/...
 ```
 
 Debian and RPM packages:


### PR DESCRIPTION
looks like cli tool is at `cmd/zek` instead of just `cmd` now