### PR TITLE
Add Option to Omit Empty Text Fields

### DIFF
--- a/cmd/zek/main.go
+++ b/cmd/zek/main.go
@@ -31,6 +31,7 @@ var (
 	compact              = flag.Bool("c", false, "emit more compact struct (noop, as this is the default since 0.1.7)")
 	nonCompact           = flag.Bool("C", false, "emit less compact struct")
 	uniqueExamples       = flag.Bool("u", false, "filter out duplicated examples")
+	omitEmptyText        = flag.Bool("m", false, "omit empty Text fields")
 )
 
 func main() {
@@ -89,6 +90,7 @@ func main() {
 		sw.ExampleMaxChars = *exampleMaxChars
 		sw.Compact = !*nonCompact
 		sw.UniqueExamples = *uniqueExamples
+		sw.OmitEmptyText = *omitEmptyText
 		if err := sw.WriteNode(root); err != nil {
 			log.Fatal(err)
 		}

--- a/structwriter.go
+++ b/structwriter.go
@@ -73,6 +73,7 @@ type StructWriter struct {
 	WithJSONTags      bool                // Include JSON struct tags.
 	Compact           bool                // Emit more compact struct.
 	UniqueExamples    bool                // Filter out duplicated examples
+	OmitEmptyText     bool                // Don't generate Text fields if no example elements have chardata.
 }
 
 // NewStructWriter can write a node to a given writer. Default list of
@@ -221,7 +222,9 @@ func (sw *StructWriter) writeNode(node *Node, top bool) (err error) {
 	if top {
 		sw.writeNameField(sew, node)
 	}
-	sw.writeChardataField(sew, node)
+	if !sw.OmitEmptyText || len(node.Examples) > 0 {
+		sw.writeChardataField(sew, node)
+	}
 
 	// Helper to check for name clash of attribute with any generated field name.
 	isValidName := func(name string) bool {

--- a/structwriter_test.go
+++ b/structwriter_test.go
@@ -55,6 +55,7 @@ func TestWriteNode(t *testing.T) {
 		input          string // Input XML filename.
 		result         string // Generated struct filename.
 		withComments   bool
+		omitEmptyText  bool
 		uniqueExamples bool
 		err            error
 	}{
@@ -131,6 +132,14 @@ func TestWriteNode(t *testing.T) {
 			uniqueExamples: true,
 			err:            nil,
 		},
+		{
+			input:          "testdata/w.14.xml",
+			result:         "testdata/w.14.go",
+			withComments:   true,
+			uniqueExamples: true,
+			omitEmptyText:  true,
+			err:            nil,
+		},
 	}
 
 	for _, c := range cases {
@@ -151,6 +160,7 @@ func TestWriteNode(t *testing.T) {
 		sw := NewStructWriter(&buf)
 		sw.WithComments = c.withComments
 		sw.UniqueExamples = c.uniqueExamples
+		sw.OmitEmptyText = c.omitEmptyText
 
 		if err := sw.WriteNode(node); err != c.err {
 			t.Errorf("WriteNode failed: got %v, want %v", err, c.err)

--- a/testdata/w.14.go
+++ b/testdata/w.14.go
@@ -1,0 +1,10 @@
+import "encoding/xml"
+
+// List was generated 2018-11-23 14:50:36 by tir on nexus.
+type List struct {
+	XMLName xml.Name `xml:"list"`
+	Value   []struct {
+		Text string `xml:",chardata"` // a
+	} `xml:"value"`
+}
+

--- a/testdata/w.14.xml
+++ b/testdata/w.14.xml
@@ -1,0 +1,4 @@
+<list>
+    <value>a</value>
+    <value>a</value>
+</list>


### PR DESCRIPTION
Add -m option to avoid generating Text fields for elements if none of
the examples of the element have character data.