### PR TITLE
added named struct extraction flag

### DIFF
--- a/cmd/zek/main.go
+++ b/cmd/zek/main.go
@@ -23,6 +23,7 @@ var (
 	debug                = flag.Bool("d", false, "debug output")
 	createExampleProgram = flag.Bool("p", false, "write out an example program")
 	tagName              = flag.String("t", "", "emit struct for tag matching this name")
+	replaceStructs       = flag.String("r", "", "replace anonymous structs by tags matching this name, e.g. 'name1 name2'")
 	skipFormatting       = flag.Bool("F", false, "skip formatting")
 	strict               = flag.Bool("s", false, "strict parsing and writing")
 	exampleMaxChars      = flag.Int("x", 25, "max chars for example")
@@ -99,6 +100,7 @@ func main() {
 	sw.Strict = *strict
 	sw.ExampleMaxChars = *exampleMaxChars
 	sw.Compact = !*nonCompact
+	sw.ReplaceStruct = strings.Split(*replaceStructs, " ")
 	sw.UniqueExamples = *uniqueExamples
 	sw.OmitEmptyText = *omitEmptyText
 	if *fixedBanner {


### PR DESCRIPTION
Hello!

Here's my suggestion for a flag allowing non-nested structs, discussed in  #14 . The diff is a bit noisy, but essentially it takes in a slice of names in the flag, then the structwriter check if the node that is about to be written as an anonymous struct is contained in this slice, and just writes the capitalized version of the name instead.

Let me know what you think!